### PR TITLE
refactor modal to include HTML dialog tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ Stretch Goals
 
 [Adding Google Maps to websites](https://developers.google.com/maps/documentation/javascript/adding-a-google-map#maps_add_map-javascript)
 
+- HTML dialog element
+[MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog)
+[Web Dev Simplified](https://blog.webdevsimplified.com/2023-04/html-dialog/)
+
 
 ## Author
 

--- a/css/loginmodal.css
+++ b/css/loginmodal.css
@@ -1,35 +1,20 @@
 /*====== LOGIN SIGN UP MODAL ======*/
 
-.modal-overlay {
-    position: fixed; /* Stay in place */
-    z-index: 1; /*Sit on top*/
-    left: 0;
-    top: 0;
-    width: 100%; /* Full width */
-    height: 100%; /* Full height */
-    overflow: auto; /* Enable scroll if needed */
-    background-color: rgb(0,0,0); /* Fallback color */
-    background-color: rgba(0,0,0, 0.8); /* Black w/ opacity */
-    padding-top: 3.75rem;
-}
-
 .login-modal {
     max-width: 800px;
-    /* background-color: var(--dark-gray); */
-    background-color: none;
+    background-color: var(--gray);
     color: var(--white);
-    position: fixed;    
-    top: 2%;
-    left: 2%;
-    right: 2%;
     padding: 1rem;
     margin: 0 auto;
     border: 2px solid var(--white);
     border-radius: var(--br-soft);
-    z-index: 2;
 }
 
-.login-modal,
+dialog::backdrop {
+    background-color: rgb(0,0,0); /*Fallback color*/
+    background-color: rgba(0,0,0, 0.8); /*Black w/ opacity*/
+}
+
 .close-modal-btn {
     display: block;
     color: var(--white);

--- a/index.css
+++ b/index.css
@@ -1,5 +1,5 @@
-@import '/css/loginmodal.css';
-@import '/css/utilities.css';
+@import 'css/loginmodal.css';
+@import 'css/utilities.css';
 @import 'css/mediaquery.css';
 @import 'css/explore.css';
 

--- a/index.html
+++ b/index.html
@@ -63,9 +63,7 @@
 
     <!-- ====== LOGIN / SIGNUP MODAL ====== -->
 
-    <div class="modal-overlay hidden" id="modal-overlay">
-        
-        <div class="login-modal hidden" id="login-modal">
+        <dialog class="login-modal" id="login-modal">
 
             <button 
                 class="close-modal-btn fa-solid fa-circle-xmark fa-xl margin-bottom" 
@@ -73,7 +71,7 @@
                 aria-label="close modal">
             </button>
 
-            <form class="modal-form" action="#">
+            <form class="modal-form" method="dialog">
                 
                 <div class="input-container">
 
@@ -87,8 +85,8 @@
 
                 <div class="form-btns">
                     
-                    <button type="submit" class="login margin-bottom" id="modal-login-btn">Login</button>
-                    <button type="button" class="signup margin-bottom" id="modal-signup-btn">Sign Up</button>
+                    <button value="login" class="login margin-bottom" id="modal-login-btn">Login</button>
+                    <button value="signup" class="signup margin-bottom" id="modal-signup-btn">Sign Up</button>
             
                     <label class="save-check-label">
                         <input type="checkbox" checked="checked" name="remember" class="save-check" id="save-check"> Remember me <!--local storage?-->
@@ -100,7 +98,7 @@
 
                     <div class="xcl-container">
                         
-                        <button type="button" class="cancel-btn" id="modal-cancel-btn">Cancel</button>
+                        <button formmethod="dialog" class="cancel-btn" id="modal-cancel-btn">Cancel</button>
                         <span class="forgot-pwd">Forgot <a href="#" class="pwd-link">password?</a></span>
                     
                     </div> <!--close xcl container-->
@@ -109,10 +107,8 @@
             
             </form>
 
-        </div> <!--close login modal div-->
+        </dialog> <!--close login modal div-->
     
-    </div><!--close modal overlay div-->
-
     <!--end form-->
 
     <!-- ====== HERO SECTION ====== -->

--- a/index.js
+++ b/index.js
@@ -7,9 +7,6 @@ Date: April 2023
 /****** VARIABLES ******/
 
 let focusedElBeforeModal;
-let loginArray = [];
-let signupArray = [];
-// const modalOverlay = document.getElementById('modal-overlay')
 const loginModal = document.getElementById('login-modal')
 const modalUsername = document.getElementById('modal-username')
 const modalPw = document.getElementById('modal-password')

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ Date: April 2023
 let focusedElBeforeModal;
 let loginArray = [];
 let signupArray = [];
-const modalOverlay = document.getElementById('modal-overlay')
+// const modalOverlay = document.getElementById('modal-overlay')
 const loginModal = document.getElementById('login-modal')
 const modalUsername = document.getElementById('modal-username')
 const modalPw = document.getElementById('modal-password')
@@ -57,27 +57,18 @@ function showModal() {
     //save current focus on the document
     focusedElBeforeModal = document.activeElement;
 
-    loginModal.classList.remove('hidden');
-    modalOverlay.classList.remove('hidden');
+    //showModal method for dialog element
+    loginModal.showModal();
 
     closeModalBtn.addEventListener('keydown', trapFocus)
     document.addEventListener('keydown', trapFocus)
-    closeModalBtn.focus();               
 }
 
 
 function hideModal() {
 
-    if (modalRememberCheckbox.checked === true) {
-        modalUsername.value = '';
-        modalPw.value = '';
-    
-    } else if (modalRememberCheckbox.checked === false) {
-        clearModal();
-    }
-
-    loginModal.classList.add('hidden');
-    modalOverlay.classList.add('hidden');
+    //close method for dialog element 
+    loginModal.close();
 
     closeModalBtn.removeEventListener('keydown', trapFocus)
     document.removeEventListener('keydown', trapFocus)
@@ -89,8 +80,6 @@ function hideModal() {
 function clearModal() {
     modalUsername.value = '';
     modalPw.value = '';
-    loginArray = [];
-    signupArray = [];
 };    
 
 
@@ -104,23 +93,15 @@ document.addEventListener('click', e => {
     } else if (e.target.dataset.modal) {
         showModal();
     
-    } else if (e.target.id === 'modal-close-btn' || (e.target == modalOverlay)) {
+    } else if (e.target.id === 'modal-close-btn' || (e.target == loginModal) || (e.target.id === 'modal-login-btn') || (e.target.id === 'modal-signup-btn')) {
         hideModal();
-        clearModal();
-    
-    } else if (e.target.id === 'modal-login-btn') {
-        e.preventDefault();
-        loginArray.push(modalUsername.value, modalPw.value);
-        hideModal();        
-   
-    } else if (e.target.id === 'modal-signup-btn') {
-        e.preventDefault()
-        signupArray.push(modalUsername.value, modalPw.value);
-        hideModal();
-
-    } else if (e.target.id === 'modal-cancel-btn') {
-        clearModal();
     }    
+    // formmethod = "dialog" on Cancel form button in HTML automatically clears the form
+
 });
 
-
+//on close, prevent form from submitting and clear the modal
+loginModal.addEventListener('close', e => {
+    e.preventDefault()
+    clearModal()
+})


### PR DESCRIPTION
```html
<dialog>
    <p>Dialog content</p>
</dialog>
```
- this HTML tag has built-in accessibility features that would have otherwise been fulfilled by ARIA roles in HTML, hiding and removing classes for display, and building extra functionality for keyboard users in JS
 - HTML form tags can take 'method' or 'formmethod' value to perform default behaviors. This will cause the form to clear automatically.
    ```html
    <button formmethod="dialog" class="cancel-btn" id="modal-cancel-btn">Cancel</button>
    ```
 - It automatically focuses the first nested element, and automatically includes ESC key functionality for keyboard users, but trapping keyboard focus for a pop-up modal is still necessary.
 - the dialog can be styled, and the backdrop that obscures the content can be achieved using the CSS ::backdrop pseudo-element,  instead of hiding and showing another HTML element
  ```css
  dialog::backdrop {
    background-color: rgb(0,0,0); /*Fallback color*/
    background-color: rgba(0,0,0, 0.8); /*Black w/ opacity*/
  }
  ``` 
  - the dialog is automatically hidden until calling a method in JavaScript, and can also be closed from JavaScript
  ```javascript
     loginModal.showModal();
     loginModal.close();
   ```
 
  
