### PR TITLE
fixed click modal close issue

### DIFF
--- a/css/mediaquery.css
+++ b/css/mediaquery.css
@@ -22,6 +22,13 @@
         align-items: center;
     }
 
+    .home-link,
+    .explore-link,
+    .signup-btn,
+    .login-btn  {
+        width: 150px;
+    }    
+
     .nav-btn {
         display: none;
     }
@@ -63,7 +70,6 @@
 
     .search-form {
         padding: 1rem 3rem;
-        /* grid-column: 2; */
         grid-column: 1 / -1;
         align-self: flex-end;
     }
@@ -119,6 +125,10 @@
     .hike-three {
         grid-row: 6;
         grid-column: 3;
+    }
+
+    .learn-link {
+        max-width: 200px;
     }
 
     .info-icon {

--- a/index.js
+++ b/index.js
@@ -74,6 +74,21 @@ function hideModal() {
     focusedElBeforeModal.focus();
 };
 
+//syntax to click outside of modal to close, but not the modal itself
+loginModal.addEventListener("click", e => {
+    //getBoundingClientRect() returns info about the size of an element and its position relative to the viewport
+    const dialogDimensions = loginModal.getBoundingClientRect()
+    //if the d
+    if (
+      e.clientX < dialogDimensions.left ||
+      e.clientX > dialogDimensions.right ||
+      e.clientY < dialogDimensions.top ||
+      e.clientY > dialogDimensions.bottom
+    ) {
+      loginModal.close()
+    }
+  })
+
 function clearModal() {
     modalUsername.value = '';
     modalPw.value = '';
@@ -90,7 +105,7 @@ document.addEventListener('click', e => {
     } else if (e.target.dataset.modal) {
         showModal();
     
-    } else if (e.target.id === 'modal-close-btn' || (e.target == loginModal) || (e.target.id === 'modal-login-btn') || (e.target.id === 'modal-signup-btn')) {
+    } else if (e.target.id === 'modal-close-btn' || /*(e.target == loginModal) ||*/ (e.target.id === 'modal-login-btn') || (e.target.id === 'modal-signup-btn')) {
         hideModal();
     }    
     // formmethod = "dialog" on Cancel form button in HTML automatically clears the form


### PR DESCRIPTION
Code for close on click outside the modal, but not the modal itself
```javascript
//syntax to click outside of modal to close, but not the modal itself
loginModal.addEventListener("click", e => {
    //getBoundingClientRect() returns info about the size of an element and its position relative to the viewport
    const dialogDimensions = loginModal.getBoundingClientRect()
    //if the d
    if (
      e.clientX < dialogDimensions.left ||
      e.clientX > dialogDimensions.right ||
      e.clientY < dialogDimensions.top ||
      e.clientY > dialogDimensions.bottom
    ) {
      loginModal.close()
    }
  })
```

[MDN getBoundingClientRect()](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect)